### PR TITLE
🔀 :: (#107) - swipe refresh layout이 lazyColumn의 scroll을 막던 오류 수정

### DIFF
--- a/buildSrc/src/main/java/Dependency.kt
+++ b/buildSrc/src/main/java/Dependency.kt
@@ -10,7 +10,6 @@ object Dependency {
         const val APPCOMPAT = "androidx.appcompat:appcompat:${Versions.Appcompat}"
         const val CONSTRAINT_LAYOUT = "androidx.constraintlayout:constraintlayout:${Versions.Constraint}"
         const val ACTIVITY_KTX = "androidx.activity:activity-ktx:${Versions.ActivityKtx}"
-        const val SPLASH_CORE = "androidx.core:core-splashscreen:${Versions.Splash}"
         const val NAVIGATION_FRAGMENT = "androidx.navigation:navigation-fragment-ktx:${Versions.Navigation}"
         const val NAVIGATION_UI_KTX = "androidx.navigation:navigation-ui-ktx:${Versions.Navigation}"
         const val SWIPE_REFRESH_LAYOUT = "androidx.swiperefreshlayout:swiperefreshlayout:${Versions.SwipeRefreshLayout}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -6,7 +6,6 @@ object Versions {
     const val Appcompat = "1.6.1"
     const val Constraint = "2.1.4"
     const val ActivityKtx = "1.2.3"
-    const val Splash = "1.0.0-beta01"
     const val Navigation = "2.5.3"
     const val SwipeRefreshLayout = "1.1.0"
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -98,21 +98,19 @@ dependencies {
     debugImplementation(Dependency.Compose.COMPOSE_MANIFEST)
     testImplementation(Dependency.ComposeTest.COMPOSE_JUNIT)
 
-    // splash
-    implementation(Dependency.AndroidX.SPLASH_CORE)
     // navigation
     implementation(Dependency.AndroidX.NAVIGATION_FRAGMENT)
     implementation(Dependency.AndroidX.NAVIGATION_UI_KTX)
 
     implementation(Dependency.AndroidX.KOTLIN_CORE)
     implementation(Dependency.AndroidX.APPCOMPAT)
+    implementation(Dependency.AndroidX.ACTIVITY_KTX)
     implementation(Dependency.AndroidX.CONSTRAINT_LAYOUT)
     implementation(Dependency.Google.MATERIAL)
     testImplementation(Dependency.Test.JUNIT)
     androidTestImplementation(Dependency.AndroidTest.TEST_JUNIT)
     androidTestImplementation(Dependency.AndroidTest.ESPRESSO)
 
-    implementation(Dependency.AndroidX.ACTIVITY_KTX)
-
     implementation(Dependency.AndroidX.SWIPE_REFRESH_LAYOUT)
+    implementation("com.google.accompanist:accompanist-swiperefresh:0.27.0")
 }

--- a/presentation/src/main/java/com/goms/presentation/view/manage/StudentManageActivity.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/manage/StudentManageActivity.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.unit.dp
@@ -25,6 +27,8 @@ import com.goms.presentation.view.manage.bottomsheet.SearchFilterBottomSheetDial
 import com.goms.presentation.view.manage.component.SearchResultEmptyScreen
 import com.goms.presentation.view.manage.component.StudentManageCard
 import com.goms.presentation.viewmodel.CouncilViewModel
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -49,11 +53,6 @@ class StudentManageActivity : AppCompatActivity() {
         }
 
         binding.studentManageBackArrowImage.setOnClickListener { finish() }
-
-        binding.swipeRefreshLayout.setOnRefreshListener {
-            studentManageLogic()
-            binding.swipeRefreshLayout.isRefreshing = false
-        }
     }
 
     private fun studentManageLogic() {
@@ -78,34 +77,37 @@ class StudentManageActivity : AppCompatActivity() {
     private suspend fun getUserList() {
         councilViewModel.getUserList()
         councilViewModel.userList.collect { list ->
-            if (list != null) {
-                initUserList(list)
-            }
+            if (list != null) initUserList(list)
         }
     }
 
     private fun initUserList(list: List<UserInfoResponseData>) {
         binding.manageStudentStudentList.setContent {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = 2.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-                contentPadding = PaddingValues(horizontal = 2.dp)
+            val isRefreshing by councilViewModel.isLoading.collectAsState()
+
+            SwipeRefresh(
+                state = rememberSwipeRefreshState(isRefreshing = isRefreshing),
+                onRefresh = { studentManageLogic() }
             ) {
-                items(list) { item ->
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .shadow(elevation = 1.dp, shape = RoundedCornerShape(10.dp))
-                    ) {
-                        StudentManageCard(
-                            item = item,
-                            iconClick = { uuid ->
-                                bottomSheetModifyRoleDialog = ModifyRoleBottomSheetDialog(uuid, item)
-                                bottomSheetModifyRoleDialog.show(supportFragmentManager, bottomSheetModifyRoleDialog.tag)
-                            }
-                        )
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    contentPadding = PaddingValues(2.dp)
+                ) {
+                    items(list) { item ->
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .shadow(elevation = 1.dp, shape = RoundedCornerShape(10.dp))
+                        ) {
+                            StudentManageCard(
+                                item = item,
+                                iconClick = { uuid ->
+                                    bottomSheetModifyRoleDialog = ModifyRoleBottomSheetDialog(uuid, item)
+                                    bottomSheetModifyRoleDialog.show(supportFragmentManager, bottomSheetModifyRoleDialog.tag)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/presentation/src/main/java/com/goms/presentation/view/manage/StudentManageActivity.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/manage/StudentManageActivity.kt
@@ -17,8 +17,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
+import com.example.presentation.R
 import com.example.presentation.databinding.ActivityStudentManageBinding
 import com.goms.domain.data.council.response.UserInfoResponseData
 import com.goms.presentation.utils.apiErrorHandling
@@ -28,6 +30,7 @@ import com.goms.presentation.view.manage.component.SearchResultEmptyScreen
 import com.goms.presentation.view.manage.component.StudentManageCard
 import com.goms.presentation.viewmodel.CouncilViewModel
 import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -87,7 +90,14 @@ class StudentManageActivity : AppCompatActivity() {
 
             SwipeRefresh(
                 state = rememberSwipeRefreshState(isRefreshing = isRefreshing),
-                onRefresh = { studentManageLogic() }
+                onRefresh = { studentManageLogic() },
+                indicator = { state, refreshTrigger ->  
+                    SwipeRefreshIndicator(
+                        state = state,
+                        refreshTriggerDistance = refreshTrigger,
+                        contentColor = colorResource(id = R.color.goms_main_color_admin)
+                    )
+                }
             ) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),

--- a/presentation/src/main/res/layout/activity_student_manage.xml
+++ b/presentation/src/main/res/layout/activity_student_manage.xml
@@ -78,24 +78,17 @@
             </LinearLayout>
         </androidx.cardview.widget.CardView>
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/manage_student_student_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="23dp"
+            android:layout_marginEnd="23dp"/>
+
         <include
             android:id="@+id/manage_student_loading_indicator"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             layout="@layout/view_loading_indicator"/>
-
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/swipe_refresh_layout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" >
-
-            <androidx.compose.ui.platform.ComposeView
-                android:id="@+id/manage_student_student_list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginStart="23dp"
-                android:layout_marginEnd="23dp"/>
-
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## 💡 개요
xml에서 구현한 swiperefreshlayout이 lazycolumn의 scroll을 막아 lazycolumn의 scroll이 안됐었음
## 📃 작업내용
xml의 swiperefreshlayout 제거
lazycolumn에서 swiperefresh로 구현
## 🔀 변경사항
불필요한 dependency 제거
xml의 swiperefreshlayout 제거
swiperefreshlayout compose로 구현
## 🙋‍♂️ 질문사항
