### PR TITLE
🔀 :: (#127) Toast 메시지 계속 뜨던 에러 고치기

### DIFF
--- a/presentation/src/main/java/com/goms/presentation/view/qr_scan/QrScanFragment.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/qr_scan/QrScanFragment.kt
@@ -78,12 +78,14 @@ class QrScanFragment : Fragment() {
         councilViewModel.makeQr.collect { uuid ->
             kotlin.runCatching {
                 if (uuid!!.outingUUID != null) {
+                    if (outingUUID == uuid.outingUUID) {
+                        Toast.makeText(context, "UUID가 갱신되지 않았습니다.", Toast.LENGTH_SHORT).show()
+                    }
                     outingUUID = uuid.outingUUID
                     createQrCode(outingUUID)
                     startTimer()
                 }
             }.onFailure {
-                Toast.makeText(context, "UUID가 갱신되지 않았습니다.", Toast.LENGTH_SHORT).show()
                 it.printStackTrace()
             }
         }


### PR DESCRIPTION
## 💡 개요
- Toast 메시지 계속 뜨는 에러 고치기
## 📃 작업내용
- Toast 위치와 조건을 조정
