### PR TITLE
🔀 :: (#146) - 권한 변경 시 뷰 자동으로 변경되게 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/data/src/main/java/com/goms/data/api/LateApi.kt
+++ b/data/src/main/java/com/goms/data/api/LateApi.kt
@@ -1,9 +1,9 @@
 package com.goms.data.api
 
-import com.goms.data.model.profile.ProfileResponse
+import com.goms.data.model.late.LateUserResponse
 import retrofit2.http.GET
 
 interface LateApi {
     @GET("late/rank")
-    suspend fun getLateRank(): List<ProfileResponse>
+    suspend fun getLateRank(): List<LateUserResponse>
 }

--- a/data/src/main/java/com/goms/data/datasource/late/LateDataSource.kt
+++ b/data/src/main/java/com/goms/data/datasource/late/LateDataSource.kt
@@ -1,8 +1,8 @@
 package com.goms.data.datasource.late
 
-import com.goms.data.model.profile.ProfileResponse
+import com.goms.data.model.late.LateUserResponse
 import kotlinx.coroutines.flow.Flow
 
 interface LateDataSource {
-    suspend fun getLateRank(): Flow<List<ProfileResponse>>
+    suspend fun getLateRank(): Flow<List<LateUserResponse>>
 }

--- a/data/src/main/java/com/goms/data/datasource/late/LateDataSourceImpl.kt
+++ b/data/src/main/java/com/goms/data/datasource/late/LateDataSourceImpl.kt
@@ -1,7 +1,7 @@
 package com.goms.data.datasource.late
 
 import com.goms.data.api.LateApi
-import com.goms.data.model.profile.ProfileResponse
+import com.goms.data.model.late.LateUserResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
@@ -9,7 +9,7 @@ import javax.inject.Inject
 class LateDataSourceImpl @Inject constructor(
     private val lateApi: LateApi
 ): LateDataSource {
-    override suspend fun getLateRank(): Flow<List<ProfileResponse>> {
+    override suspend fun getLateRank(): Flow<List<LateUserResponse>> {
         return flow {
             emit(lateApi.getLateRank())
         }

--- a/data/src/main/java/com/goms/data/mapper/AuthMapper.kt
+++ b/data/src/main/java/com/goms/data/mapper/AuthMapper.kt
@@ -1,6 +1,8 @@
 package com.goms.data.mapper
 
+import com.goms.data.model.auth.response.RefreshTokenResponse
 import com.goms.data.model.auth.response.SignInResponse
+import com.goms.domain.data.auth.response.RefreshTokenResponseData
 import com.goms.domain.data.auth.response.SignInResponseData
 
 object AuthMapper {
@@ -11,6 +13,16 @@ object AuthMapper {
             accessTokenExp = signInResponse.accessTokenExpiredAt,
             refreshTokenExp = signInResponse.refreshTokenExpiredAt,
             authority = signInResponse.authority
+        )
+    }
+
+    fun refreshTokenResponseToData(refreshTokenResponse: RefreshTokenResponse): RefreshTokenResponseData {
+        return RefreshTokenResponseData(
+            accessToken = refreshTokenResponse.accessToken,
+            refreshToken = refreshTokenResponse.refreshToken,
+            accessTokenExpiredAt = refreshTokenResponse.accessTokenExpiredAt,
+            refreshTokenExpiredAt = refreshTokenResponse.refreshTokenExpiredAt,
+            authority = refreshTokenResponse.authority
         )
     }
 }

--- a/data/src/main/java/com/goms/data/mapper/LateMapper.kt
+++ b/data/src/main/java/com/goms/data/mapper/LateMapper.kt
@@ -1,0 +1,16 @@
+package com.goms.data.mapper
+
+import com.goms.data.mapper.util.StudentInfoMapper
+import com.goms.data.model.late.LateUserResponse
+import com.goms.domain.data.late.LateUserResponseData
+
+object LateMapper {
+    fun lateUserResponseToData(lateUserResponse: LateUserResponse): LateUserResponseData {
+        return LateUserResponseData(
+            accountIdx = lateUserResponse.accountIdx,
+            name = lateUserResponse.name,
+            studentNum = StudentInfoMapper.studentInfoToData(lateUserResponse.studentNum),
+            profileUrl = lateUserResponse.profileUrl
+        )
+    }
+}

--- a/data/src/main/java/com/goms/data/mapper/ProfileMapper.kt
+++ b/data/src/main/java/com/goms/data/mapper/ProfileMapper.kt
@@ -10,6 +10,7 @@ object ProfileMapper {
             accountIdx = profileResponse.accountIdx,
             name = profileResponse.name,
             studentNum = StudentInfoMapper.studentInfoToData(profileResponse.studentNum),
+            authority = profileResponse.authority,
             profileUrl = profileResponse.profileUrl,
             lateCount = profileResponse.lateCount,
             isOuting = profileResponse.isOuting,

--- a/data/src/main/java/com/goms/data/model/late/LateUserResponse.kt
+++ b/data/src/main/java/com/goms/data/model/late/LateUserResponse.kt
@@ -1,0 +1,12 @@
+package com.goms.data.model.late
+
+import com.goms.data.model.util.StudentInfo
+import com.google.gson.annotations.SerializedName
+import java.util.UUID
+
+data class LateUserResponse(
+    @SerializedName("accountIdx") val accountIdx: UUID,
+    @SerializedName("name") val name: String,
+    @SerializedName("studentNum") val studentNum: StudentInfo,
+    @SerializedName("profileUrl") val profileUrl: String?
+)

--- a/data/src/main/java/com/goms/data/model/profile/ProfileResponse.kt
+++ b/data/src/main/java/com/goms/data/model/profile/ProfileResponse.kt
@@ -8,6 +8,7 @@ data class ProfileResponse(
     @SerializedName("accountIdx") val accountIdx: UUID,
     @SerializedName("name") val name: String,
     @SerializedName("studentNum") val studentNum: StudentInfo,
+    @SerializedName("authority") val authority: String,
     @SerializedName("profileUrl") val profileUrl: String?,
     @SerializedName("lateCount") val lateCount: Int,
     @SerializedName("isOuting") val isOuting: Boolean,

--- a/data/src/main/java/com/goms/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/goms/data/repository/AuthRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.goms.data.datasource.auth.AuthDataSource
 import com.goms.data.datasource.token.AuthTokenDataSource
 import com.goms.data.mapper.AuthMapper
+import com.goms.domain.data.auth.response.RefreshTokenResponseData
 import com.goms.domain.data.auth.response.SignInResponseData
 import com.goms.domain.exception.NeedLoginException
 import com.goms.domain.repository.AuthRepository
@@ -66,5 +67,13 @@ class AuthRepositoryImpl @Inject constructor(
         refreshTokenExp: String
     ) {
         authTokenDataSource.setToken(accessToken, refreshToken, accessTokenExp, refreshTokenExp)
+    }
+
+    override suspend fun refreshToken(refreshToken: String): Flow<RefreshTokenResponseData> {
+        return flow {
+            authDataSource.refreshToken(refreshToken).collect {
+                emit(AuthMapper.refreshTokenResponseToData(it))
+            }
+        }
     }
 }

--- a/data/src/main/java/com/goms/data/repository/LateRepositoryImpl.kt
+++ b/data/src/main/java/com/goms/data/repository/LateRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.goms.data.repository
 
 import com.goms.data.datasource.late.LateDataSource
-import com.goms.data.mapper.ProfileMapper
-import com.goms.domain.data.profile.ProfileResponseData
+import com.goms.data.mapper.LateMapper
+import com.goms.domain.data.late.LateUserResponseData
 import com.goms.domain.repository.LateRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -11,10 +11,10 @@ import javax.inject.Inject
 class LateRepositoryImpl @Inject constructor(
     private val lateDataSource: LateDataSource
 ): LateRepository {
-    override suspend fun getLateRank(): Flow<List<ProfileResponseData>> {
+    override suspend fun getLateRank(): Flow<List<LateUserResponseData>> {
         return flow {
             lateDataSource.getLateRank().collect { list ->
-                emit(list.map { ProfileMapper.profileResponseToData(it) })
+                emit(list.map { LateMapper.lateUserResponseToData(it) })
             }
         }
     }

--- a/domain/src/main/java/com/goms/domain/data/auth/response/RefreshTokenResponseData.kt
+++ b/domain/src/main/java/com/goms/domain/data/auth/response/RefreshTokenResponseData.kt
@@ -1,0 +1,9 @@
+package com.goms.domain.data.auth.response
+
+data class RefreshTokenResponseData(
+    val accessToken: String,
+    val refreshToken: String,
+    val accessTokenExpiredAt: String?,
+    val refreshTokenExpiredAt: String?,
+    val authority: String
+)

--- a/domain/src/main/java/com/goms/domain/data/late/LateUserResponseData.kt
+++ b/domain/src/main/java/com/goms/domain/data/late/LateUserResponseData.kt
@@ -1,0 +1,11 @@
+package com.goms.domain.data.late
+
+import com.goms.domain.data.util.StudentInfoData
+import java.util.UUID
+
+data class LateUserResponseData(
+    val accountIdx: UUID,
+    val name: String,
+    val studentNum: StudentInfoData,
+    val profileUrl: String?
+)

--- a/domain/src/main/java/com/goms/domain/data/profile/ProfileResponseData.kt
+++ b/domain/src/main/java/com/goms/domain/data/profile/ProfileResponseData.kt
@@ -8,6 +8,7 @@ data class ProfileResponseData(
     val accountIdx: UUID,
     val name: String,
     val studentNum: StudentInfoData,
+    val authority: String,
     val profileUrl: String?,
     val lateCount: Int,
     val isOuting: Boolean,

--- a/domain/src/main/java/com/goms/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/goms/domain/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.goms.domain.repository
 
+import com.goms.domain.data.auth.response.RefreshTokenResponseData
 import com.goms.domain.data.auth.response.SignInResponseData
 import kotlinx.coroutines.flow.Flow
 
@@ -21,4 +22,6 @@ interface AuthRepository {
         accessTokenExp: String,
         refreshTokenExp: String
     )
+
+    suspend fun refreshToken(refreshToken: String): Flow<RefreshTokenResponseData>
 }

--- a/domain/src/main/java/com/goms/domain/repository/LateRepository.kt
+++ b/domain/src/main/java/com/goms/domain/repository/LateRepository.kt
@@ -1,8 +1,8 @@
 package com.goms.domain.repository
 
-import com.goms.domain.data.profile.ProfileResponseData
+import com.goms.domain.data.late.LateUserResponseData
 import kotlinx.coroutines.flow.Flow
 
 interface LateRepository {
-    suspend fun getLateRank(): Flow<List<ProfileResponseData>>
+    suspend fun getLateRank(): Flow<List<LateUserResponseData>>
 }

--- a/domain/src/main/java/com/goms/domain/usecase/auth/RefreshTokenUseCase.kt
+++ b/domain/src/main/java/com/goms/domain/usecase/auth/RefreshTokenUseCase.kt
@@ -1,0 +1,12 @@
+package com.goms.domain.usecase.auth
+
+import com.goms.domain.data.auth.response.RefreshTokenResponseData
+import com.goms.domain.repository.AuthRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class RefreshTokenUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(refreshToken: String): Flow<RefreshTokenResponseData> = authRepository.refreshToken(refreshToken)
+}

--- a/domain/src/main/java/com/goms/domain/usecase/late/LateUseCase.kt
+++ b/domain/src/main/java/com/goms/domain/usecase/late/LateUseCase.kt
@@ -1,6 +1,6 @@
 package com.goms.domain.usecase.late
 
-import com.goms.domain.data.profile.ProfileResponseData
+import com.goms.domain.data.late.LateUserResponseData
 import com.goms.domain.repository.LateRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class LateUseCase @Inject constructor(
     private val lateRepository: LateRepository
 ) {
-    suspend operator fun invoke(): Flow<List<ProfileResponseData>> {
+    suspend operator fun invoke(): Flow<List<LateUserResponseData>> {
         return lateRepository.getLateRank()
     }
 }

--- a/presentation/src/main/java/com/goms/presentation/di/module/UseCaseModule.kt
+++ b/presentation/src/main/java/com/goms/presentation/di/module/UseCaseModule.kt
@@ -12,6 +12,7 @@ import com.goms.domain.usecase.admin.SearchStudentUseCase
 import com.goms.domain.usecase.admin.SetBlackListUseCase
 import com.goms.domain.usecase.admin.UserListUseCase
 import com.goms.domain.usecase.auth.CheckLoginUseCase
+import com.goms.domain.usecase.auth.RefreshTokenUseCase
 import com.goms.domain.usecase.auth.SetTokenUseCase
 import com.goms.domain.usecase.auth.SignInUseCase
 import com.goms.domain.usecase.late.LateUseCase
@@ -28,6 +29,12 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object UseCaseModule {
+
+    @Provides
+    @Singleton
+    fun provideRefreshTokenUseCase(authRepository: AuthRepository): RefreshTokenUseCase {
+        return RefreshTokenUseCase(authRepository)
+    }
 
     @Provides
     @Singleton

--- a/presentation/src/main/java/com/goms/presentation/view/home/HomeFragment.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/home/HomeFragment.kt
@@ -34,6 +34,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import coil.load
+import com.goms.domain.data.late.LateUserResponseData
 import com.goms.domain.data.profile.ProfileResponseData
 import com.goms.presentation.R
 import com.goms.presentation.databinding.FragmentHomeBinding
@@ -216,7 +217,7 @@ class HomeFragment : Fragment() {
     }
 
     @Composable
-    private fun LateLazyRow(list: List<ProfileResponseData>) {
+    private fun LateLazyRow(list: List<LateUserResponseData>) {
         LazyRow(
             modifier = Modifier
                 .fillMaxWidth()

--- a/presentation/src/main/java/com/goms/presentation/view/home/component/HomeItemCard.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/home/component/HomeItemCard.kt
@@ -22,12 +22,12 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.goms.domain.data.profile.ProfileResponseData
+import com.goms.domain.data.late.LateUserResponseData
 import com.goms.presentation.R
 import com.skydoves.landscapist.coil.CoilImage
 
 @Composable
-fun HomeItemCard(item: ProfileResponseData) {
+fun HomeItemCard(item: LateUserResponseData) {
     val homeCardFont = FontFamily(
         Font(R.font.sf_pro_text_regular, FontWeight.Normal),
         Font(R.font.sf_pro_text_medium, FontWeight.Medium)

--- a/presentation/src/main/java/com/goms/presentation/view/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/splash/SplashActivity.kt
@@ -2,6 +2,7 @@ package com.goms.presentation.view.splash
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.content.SharedPreferences
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Bundle
@@ -10,27 +11,60 @@ import android.os.Looper
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import com.goms.presentation.R
 import com.goms.presentation.view.main.MainActivity
 import com.goms.presentation.view.sign_in.SignInActivity
+import com.goms.presentation.viewmodel.ProfileViewModel
 import com.goms.presentation.viewmodel.SplashViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @SuppressLint("CustomSplashScreen")
 @AndroidEntryPoint
 class SplashActivity : AppCompatActivity() {
     private val splashViewModel by viewModels<SplashViewModel>()
+    private val profileViewModel by viewModels<ProfileViewModel>()
+
+    private lateinit var sharedPreferences: SharedPreferences
+    private lateinit var tokenSf: SharedPreferences
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
 
+        sharedPreferences = getSharedPreferences("userOuting", MODE_PRIVATE)
+        if (!sharedPreferences.contains("outingStatus"))
+            initSharedPreference()
+
+        tokenSf = getSharedPreferences("token", MODE_PRIVATE)
+        val refreshToken = tokenSf.getString("refreshToken", "")
+
+        if (!refreshToken.isNullOrEmpty()) {
+            splashViewModel.refreshToken(refreshToken)
+            saveToken()
+
+            profileViewModel.getProfileLogic()
+        }
+
         Handler(Looper.getMainLooper()).postDelayed({
             if (checkIsInterConnected()) {
-                splashViewModel.checkIsLogin()
-                observeLogin()
+                if (refreshToken.isNullOrEmpty()) {
+                    splashViewModel.checkIsLogin()
+                    observeLogin()
+                } else {
+                    splashViewModel.checkIsLogin()
+                    saveRole()
+                    observeLogin()
+                }
             } else Toast.makeText(this, "인터넷 없음", Toast.LENGTH_SHORT).show()
         }, 1000)
+    }
+
+    private fun initSharedPreference() {
+        sharedPreferences.edit()
+            .putBoolean("outingStatus", false)
+            .apply()
     }
 
     private fun observeLogin() {
@@ -44,6 +78,34 @@ class SplashActivity : AppCompatActivity() {
                     false -> {
                         startActivity(Intent(this, SignInActivity::class.java))
                         finish()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun saveRole() {
+        lifecycleScope.launch {
+            profileViewModel.profile.collect { profile ->
+                val authSf = getSharedPreferences("authority", MODE_PRIVATE)
+                authSf.edit().let {
+                    it.putString("role", profile?.authority)
+                    it.apply()
+                }
+            }
+        }
+    }
+
+    private fun saveToken() {
+        lifecycleScope.launch {
+            splashViewModel.token.collect { token ->
+                if (token != null) {
+                    tokenSf.edit().let {
+                        it.putString("accessToken", token.accessToken)
+                        it.putString("refreshToken", token.refreshToken)
+                        it.putString("accessTokenExp", token.accessTokenExpiredAt)
+                        it.putString("refreshTokenExp", token.refreshTokenExpiredAt)
+                        it.apply()
                     }
                 }
             }

--- a/presentation/src/main/java/com/goms/presentation/viewmodel/LateViewModel.kt
+++ b/presentation/src/main/java/com/goms/presentation/viewmodel/LateViewModel.kt
@@ -1,7 +1,7 @@
 package com.goms.presentation.viewmodel
 
 import androidx.lifecycle.ViewModel
-import com.goms.domain.data.profile.ProfileResponseData
+import com.goms.domain.data.late.LateUserResponseData
 import com.goms.domain.exception.FailAccessTokenException
 import com.goms.domain.exception.OtherException
 import com.goms.domain.exception.ServerException
@@ -19,8 +19,8 @@ import javax.inject.Inject
 class LateViewModel @Inject constructor(
     private val lateUseCase: LateUseCase
 ): ViewModel() {
-    private val _lateRanking: MutableStateFlow<List<ProfileResponseData>?> = MutableStateFlow(null)
-    val lateRanking: StateFlow<List<ProfileResponseData>?> = _lateRanking
+    private val _lateRanking: MutableStateFlow<List<LateUserResponseData>?> = MutableStateFlow(null)
+    val lateRanking: StateFlow<List<LateUserResponseData>?> = _lateRanking
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading

--- a/presentation/src/main/java/com/goms/presentation/viewmodel/SplashViewModel.kt
+++ b/presentation/src/main/java/com/goms/presentation/viewmodel/SplashViewModel.kt
@@ -4,23 +4,53 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.goms.domain.data.auth.response.RefreshTokenResponseData
+import com.goms.domain.exception.NotRequestParamException
+import com.goms.domain.exception.OtherException
+import com.goms.domain.exception.ServerException
+import com.goms.domain.exception.UserNotFoundException
 import com.goms.domain.usecase.auth.CheckLoginUseCase
+import com.goms.domain.usecase.auth.RefreshTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val checkLoginUseCase: CheckLoginUseCase
+    private val checkLoginUseCase: CheckLoginUseCase,
+    private val refreshTokenUseCase: RefreshTokenUseCase
 ): ViewModel() {
     private val _isLogin = MutableLiveData<Boolean?>(null)
     val isLogin: LiveData<Boolean?> = _isLogin
+
+    private val _token = MutableStateFlow<RefreshTokenResponseData?>(null)
+    val token: StateFlow<RefreshTokenResponseData?> = _token
 
     fun checkIsLogin() = viewModelScope.launch {
         checkLoginUseCase().onSuccess {
             _isLogin.value = true
         }.onFailure {
             _isLogin.value = false
+        }
+    }
+
+    fun refreshToken(refreshToken: String) {
+        viewModelScope.launch {
+            refreshTokenUseCase("Bearer $refreshToken").catch {
+                if (it is HttpException) {
+                    when (it.code()) {
+                        400 -> throw NotRequestParamException("토큰 요청이 올바르지 않습니다.")
+                        404 -> throw UserNotFoundException("계정을 찾을 수 없습니다.")
+                        500 -> throw ServerException("서버 에러")
+                    }
+                } else throw OtherException(it.message)
+            }.collect {
+                _token.value = it
+            }
         }
     }
 }


### PR DESCRIPTION
## 💡 개요
권한 변경 시 뷰 자동으로 변경되게 수정하기

## 📃 작업내용
토큰 재발급 로직 확장(repository, usecase, viewmodel)
splash에서 토큰 한번 재발급해 변경된 권한 적용하는 로직 작성
profile 정보를 불러와 사용자의 권한 미리 sharedPreference로 저장하는 로직 작성

## 🔀 변경사항
## 🙋‍♂️ 질문사항