### PR TITLE
🔀 :: (#176) splash 로직 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="Embedded JDK" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/data/src/main/java/com/goms/data/mapper/ProfileMapper.kt
+++ b/data/src/main/java/com/goms/data/mapper/ProfileMapper.kt
@@ -7,7 +7,6 @@ import com.goms.domain.data.profile.ProfileResponseData
 object ProfileMapper {
     fun profileResponseToData(profileResponse: ProfileResponse): ProfileResponseData {
         return ProfileResponseData(
-            accountIdx = profileResponse.accountIdx,
             name = profileResponse.name,
             studentNum = StudentInfoMapper.studentInfoToData(profileResponse.studentNum),
             authority = profileResponse.authority,

--- a/data/src/main/java/com/goms/data/model/profile/ProfileResponse.kt
+++ b/data/src/main/java/com/goms/data/model/profile/ProfileResponse.kt
@@ -2,10 +2,8 @@ package com.goms.data.model.profile
 
 import com.goms.data.model.util.StudentInfo
 import com.google.gson.annotations.SerializedName
-import java.util.UUID
 
 data class ProfileResponse(
-    @SerializedName("accountIdx") val accountIdx: UUID,
     @SerializedName("name") val name: String,
     @SerializedName("studentNum") val studentNum: StudentInfo,
     @SerializedName("authority") val authority: String,

--- a/data/src/main/java/com/goms/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/goms/data/repository/AuthRepositoryImpl.kt
@@ -35,7 +35,7 @@ class AuthRepositoryImpl @Inject constructor(
         val currentTime = LocalDateTime.now()
         val accessTokenExp = authTokenDataSource.getAccessTokenExp()
         val refreshTokenExp = authTokenDataSource.getRefreshTokenExp()
-        val parsePattern = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss")
+        val parsePattern = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
         val refreshExpireDate = LocalDateTime.parse(refreshTokenExp, parsePattern)
         val accessExpireDate = LocalDateTime.parse(accessTokenExp, parsePattern)
 

--- a/domain/src/main/java/com/goms/domain/data/profile/ProfileResponseData.kt
+++ b/domain/src/main/java/com/goms/domain/data/profile/ProfileResponseData.kt
@@ -2,10 +2,8 @@ package com.goms.domain.data.profile
 
 import com.goms.domain.data.util.StudentInfoData
 import java.io.Serializable
-import java.util.UUID
 
 data class ProfileResponseData(
-    val accountIdx: UUID,
     val name: String,
     val studentNum: StudentInfoData,
     val authority: String,

--- a/presentation/src/main/java/com/goms/presentation/view/main/MainActivity.kt
+++ b/presentation/src/main/java/com/goms/presentation/view/main/MainActivity.kt
@@ -53,8 +53,14 @@ class MainActivity : AppCompatActivity() {
             binding.gomsBottomNavigationView.menu.findItem(R.id.qrScanFragment).setIcon(R.drawable.qr_code_icon)
         }
 
+        val intentExtra = intent.getSerializableExtra("profile") as ProfileResponseData?
+        if (intentExtra == null) setProfile()
+        else {
+            response = intentExtra
+            binding.mainCircleProfileIcon.load(intentExtra.profileUrl ?: R.drawable.user_profile)
+        }
+
         setNavigation()
-        setProfile()
         binding.mainCircleProfileIcon.setOnClickListener {
             startActivity(Intent(this, ProfileActivity::class.java)
                 .putExtra("profile", response))

--- a/presentation/src/main/java/com/goms/presentation/viewmodel/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/goms/presentation/viewmodel/ProfileViewModel.kt
@@ -27,20 +27,22 @@ class ProfileViewModel @Inject constructor(
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
 
-    fun getProfileLogic() = viewModelScope.launch {
-        profileUseCase().onStart {
-            _isLoading.value = true
-        }.onCompletion {
-            _isLoading.value = false
-        }.catch {
-            if (it is HttpException) {
-                when (it.code()) {
-                    401 -> throw FailAccessTokenException("access token이 유효하지 않습니다")
-                    500 -> throw ServerException("서버 에러")
-                }
-            } else throw OtherException(it.message)
-        }.collect {
-            _profile.value = it
+    fun getProfileLogic() {
+        viewModelScope.launch {
+            profileUseCase().onStart {
+                _isLoading.value = true
+            }.onCompletion {
+                _isLoading.value = false
+            }.catch {
+                if (it is HttpException) {
+                    when (it.code()) {
+                        401 -> throw FailAccessTokenException("access token이 유효하지 않습니다")
+                        500 -> throw ServerException("서버 에러")
+                    }
+                } else throw OtherException(it.message)
+            }.collect {
+                _profile.value = it
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/goms/presentation/viewmodel/SignInViewModel.kt
+++ b/presentation/src/main/java/com/goms/presentation/viewmodel/SignInViewModel.kt
@@ -33,26 +33,28 @@ class SignInViewModel @Inject constructor(
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
 
-    fun signInLogic(code: String) = viewModelScope.launch {
-        signInUseCase(code).onStart {
-            _isLoading.value = true
-        }.onCompletion {
-            _isLoading.value = false
-        }.catch {
-            if (it is HttpException) {
-                when(it.code()) {
-                    400 -> throw NotRequestParamException("gauth code가 이미 사용되었습니다")
-                    500 -> throw ServerException("서버 에러")
-                }
-            } else throw OtherException(it.message)
-        }.collect { response ->
-            setTokenUseCase(
-                accessToken = response.accessToken,
-                refreshToken = response.refreshToken,
-                accessTokenExp = response.accessTokenExp.toString(),
-                refreshTokenExp = response.refreshTokenExp.toString()
-            )
-            _signIn.value = response
+    fun signInLogic(code: String) {
+        viewModelScope.launch {
+            signInUseCase(code).onStart {
+                _isLoading.value = true
+            }.onCompletion {
+                _isLoading.value = false
+            }.catch {
+                if (it is HttpException) {
+                    when(it.code()) {
+                        400 -> throw NotRequestParamException("gauth code가 이미 사용되었습니다")
+                        500 -> throw ServerException("서버 에러")
+                    }
+                } else throw OtherException(it.message)
+            }.collect { response ->
+                setTokenUseCase(
+                    accessToken = response.accessToken,
+                    refreshToken = response.refreshToken,
+                    accessTokenExp = response.accessTokenExp.toString(),
+                    refreshTokenExp = response.refreshTokenExp.toString()
+                )
+                _signIn.value = response
+            }
         }
     }
 

--- a/presentation/src/main/java/com/goms/presentation/viewmodel/SplashViewModel.kt
+++ b/presentation/src/main/java/com/goms/presentation/viewmodel/SplashViewModel.kt
@@ -30,11 +30,13 @@ class SplashViewModel @Inject constructor(
     private val _token = MutableStateFlow<RefreshTokenResponseData?>(null)
     val token: StateFlow<RefreshTokenResponseData?> = _token
 
-    fun checkIsLogin() = viewModelScope.launch {
-        checkLoginUseCase().onSuccess {
-            _isLogin.value = true
-        }.onFailure {
-            _isLogin.value = false
+    fun checkIsLogin() {
+        viewModelScope.launch {
+            checkLoginUseCase().onSuccess {
+                _isLogin.value = true
+            }.onFailure {
+                _isLogin.value = false
+            }
         }
     }
 


### PR DESCRIPTION
## 💡 개요
- 로그인 로직 손보기

## 📃 작업내용
- splash 로직을 로그인 상태에 따라서 로직이 수행되게 수정하였음.(observeLogin 함수에서 isLogin 상태에 따라서 처리되게 수정함.)
- 로그인이 되어 있으면 splash에서 profile api를 호출하는데, main activity에서 putExtra로 받아서 api 호출을 최소화하기 위해 profile data를 받아와 사용하는 로직을 만들었음.

## 🔀 변경사항
- localDateTime format pattern 변경
- 필요없어진 profile response accountIdx 삭제
- splash 로직 변경
- main screen에서 profile data 받아와 사용하는 로직 생성

## 🙋‍♂️ 질문사항
